### PR TITLE
fix: avoid treating json arguments as config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@
 需要 Go 1.18+ 和 Git。
 
 ```bash
-git clone https://github.com/zhangjingwei/kuake_sdk.git
-cd kuake_sdk
+git clone https://github.com/zhangjingwei/kuake_cli.git
+cd kuake_cli
 chmod +x build.sh
 ./build.sh
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,17 @@ type CLIResult struct {
 	Data    map[string]interface{} `json:"data,omitempty"`
 }
 
+// isLegacyConfigArg keeps deprecated positional config support without
+// breaking commands whose first argument legitimately ends with .json.
+func isLegacyConfigArg(arg string) bool {
+	if filepath.Ext(arg) != ".json" {
+		return false
+	}
+
+	_, err := sdk.LoadConfig(arg)
+	return err == nil
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		printUsage()
@@ -103,8 +114,8 @@ func main() {
 			command = arg
 		} else {
 			// 后续参数是命令参数
-			// 如果第一个参数是 .json 文件（向后兼容），也作为配置文件
-			if len(args) == 0 && filepath.Ext(arg) == ".json" {
+			// 如果第一个参数是可识别的 kuake 配置文件（向后兼容），也作为配置文件
+			if len(args) == 0 && isLegacyConfigArg(arg) {
 				configPath = arg
 			} else {
 				args = append(args, arg)
@@ -620,7 +631,7 @@ func handleUpload(client *sdk.QuarkClient, args []string) *CLIResult {
 func handleList(client *sdk.QuarkClient, args []string) *CLIResult {
 	dirPath := "/"
 	streamMode := false
-	
+
 	// 解析参数，支持 --stream 选项
 	var filteredArgs []string
 	for i, arg := range args {
@@ -703,7 +714,7 @@ func handleInfo(client *sdk.QuarkClient, args []string) *CLIResult {
 				// 只有 fid 时，尝试直接使用（某些 API 可能支持）
 				targetPath = fid
 			}
-			
+
 			if targetPath == "" {
 				return &CLIResult{
 					Success: false,
@@ -968,7 +979,7 @@ func handleDelete(client *sdk.QuarkClient, args []string) *CLIResult {
 				// 尝试直接使用 fid 作为路径（某些情况下可能有效）
 				targetPath = fid
 			}
-			
+
 			if targetPath == "" {
 				return &CLIResult{
 					Success: false,
@@ -1121,7 +1132,7 @@ func handleDownload(client *sdk.QuarkClient, args []string) *CLIResult {
 				// 只有 fid 时，尝试直接使用
 				targetPath = fid
 			}
-			
+
 			if targetPath == "" {
 				return &CLIResult{
 					Success: false,

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsLegacyConfigArg(t *testing.T) {
+	validConfig := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(validConfig, []byte(`{
+  "Quark": {
+    "access_tokens": ["__pus=test;"]
+  }
+}`), 0644); err != nil {
+		t.Fatalf("failed to write valid config: %v", err)
+	}
+
+	plainJSON := filepath.Join(t.TempDir(), "test.json")
+	if err := os.WriteFile(plainJSON, []byte(`{"name":"fixture"}`), 0644); err != nil {
+		t.Fatalf("failed to write plain json: %v", err)
+	}
+
+	if !isLegacyConfigArg(validConfig) {
+		t.Fatalf("expected valid kuake config to be recognized")
+	}
+
+	if isLegacyConfigArg(plainJSON) {
+		t.Fatalf("expected ordinary json file not to be recognized as config")
+	}
+
+	if isLegacyConfigArg("missing.json") {
+		t.Fatalf("expected missing json file not to be recognized as config")
+	}
+}

--- a/sdk/quark_client.go
+++ b/sdk/quark_client.go
@@ -30,7 +30,7 @@ func NewQuarkClient(configPath string, cookies ...string) *QuarkClient {
 		// 否则从配置文件加载
 		config, err := LoadConfig(configPath)
 		if err != nil {
-			panic("failed to load config file")
+			panic(fmt.Errorf("failed to load config file: %w", err))
 		}
 
 		accessTokens = config.Quark.AccessTokens


### PR DESCRIPTION
## Summary
- only treat a positional .json argument as legacy config when it loads as a valid kuake config
- preserve the underlying config load error during client initialization
- add parser coverage for valid config vs ordinary json files

## Testing
- env GOCACHE=/tmp/kuake-go-build go test ./cmd -run TestIsLegacyConfigArg
- env GOCACHE=/tmp/kuake-go-build go test ./sdk -run 'TestNewQuarkClient|TestLoadConfig'